### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/swig/rsasign.py
+++ b/swig/rsasign.py
@@ -5,13 +5,13 @@ import wolfssl
 
 # start Random Number Generator
 rng = wolfssl.GetRng()
-if rng == None:
+if rng is None:
     print "Couldn't get an RNG"
     exit(-1)
 
 # load RSA private key in DER format
 key = wolfssl.GetRsaPrivateKey("../certs/client-key.der")
-if key == None:
+if key is None:
     print "Couldn't load DER private key file"
     exit(-1)
 

--- a/swig/runme.py
+++ b/swig/runme.py
@@ -8,7 +8,7 @@ print "Trying to connect to the example server -d..."
 wolfssl.wolfSSL_Init()
 #wolfssl.wolfSSL_Debugging_ON()
 ctx = wolfssl.wolfSSL_CTX_new(wolfssl.wolfTLSv1_2_client_method())
-if ctx == None:
+if ctx is None:
     print "Couldn't get SSL CTX for TLSv1.2"
     exit(-1)
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:wolfssl?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:wolfssl?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
